### PR TITLE
Update communication.ts

### DIFF
--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -672,12 +672,15 @@ async function shouldProcessMessage(messageSource: Window, messageOrigin: string
     messageOrigin === Communication.currentWindow.location.origin
   ) {
     return true;
-  } else {
+  } else if (messageOrigin) {
     const isOriginValid = await validateOrigin(new URL(messageOrigin));
     if (!isOriginValid) {
       shouldProcessMessageLogger('Message has an invalid origin of %s', messageOrigin);
     }
     return isOriginValid;
+  } else {
+    shouldProcessMessageLogger('Message has no origin defined');
+    return false;
   }
 }
 


### PR DESCRIPTION
Validate empty origin

While creating URL from empty string, we would see `Failed to construct 'URL': Invalid URL` while validating the message origin. Add extra check to include this case.